### PR TITLE
fix get_keyword() for "{method_name} not found, maybe you meant" view

### DIFF
--- a/autoload/ref/ri.vim
+++ b/autoload/ref/ri.vim
@@ -62,7 +62,7 @@ function! s:source.get_keyword() " {{{2
       end
     endif
   endif
-  return expand('<cword>')
+  return ref#get_text_on_cursor('\v((\w+\:\:)*(\w+[.#]))?\w+[!?]{0,1}')
 endfunction
 
 function! s:source.complete(query) " {{{2


### PR DESCRIPTION
:Ref ri nil

```
.nil not found, maybe you meant:

NilClass#nil?
Object#nil?
Scanf::FormatSpecifier#nil_proc
```

このような出力の時に正しくジャンプできるようにしました
