### PR TITLE
fix rdoc syntax for _word_ and *word*: force end at EOL

### DIFF
--- a/autoload/ref/ri.vim
+++ b/autoload/ref/ri.vim
@@ -86,8 +86,8 @@ function! s:syntax() "
   syntax sync linebreaks=1
 
   " RDoc text markup
-  syntax region rdocBold      start=/\\\@<!\(^\|\A\)\@=\*\(\s\|\W\)\@!\(\a\{1,}\s\|$\n\)\@!/ skip=/\\\*/ end=/\*\($\|\A\|\s\|\n\)\@=/ contains=@Spell
-  syntax region rdocEmphasis  start=/\\\@<!\(^\|\A\)\@=_\(\s\|\W\)\@!\(\a\{1,}\s\|$\n\)\@!/  skip=/\\_/  end=/_\($\|\A\|\s\|\n\)\@=/  contains=@Spell
+  syntax region rdocBold      start=/\\\@<!\(^\|\A\)\@=\*\(\s\|\W\)\@!\(\a\{1,}\s\|$\n\)\@!/ skip=/\\\*/ end=/$\|\*\($\|\A\|\s\|\n\)\@=/ contains=@Spell
+  syntax region rdocEmphasis  start=/\\\@<!\(^\|\A\)\@=_\(\s\|\W\)\@!\(\a\{1,}\s\|$\n\)\@!/  skip=/\\_/  end=/$\|_\($\|\A\|\s\|\n\)\@=/  contains=@Spell
   "syntax region rdocMonospace start=/\\\@<!\(^\|\A\)\@=+\(\s\|\W\)\@!\(\a\{1,}\s\|$\n\)\@!/  skip=/\\+/  end=/+\($\|\A\|\s\|\n\)\@=/  contains=@Spell
 
   " RDoc links: {link}[URL]


### PR DESCRIPTION
文中に_が出現したときおかしくなるので､改行で強制的に区切るようにしました

http://gyazo.com/63d0de025f5bc3b3db6b6129ced8fb31
